### PR TITLE
Updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,12 @@
 {
-  "extensions": [
-    "julialang.language-julia",
-    "ms-vscode.cpptools",
-    "ms-vscode.cmake-tools"
-  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "julialang.language-julia",
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools"
+      ]
+    }
+  },
   "dockerFile": "Dockerfile"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(Foo)
+cmake_minimum_required(VERSION 3.5)
 
-cmake_minimum_required(VERSION 3.1)
+project(Foo)
 
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")

--- a/testfoo.jl
+++ b/testfoo.jl
@@ -3,7 +3,7 @@ using Test
 module ModFoo
     using CxxWrap
 
-    @wrapmodule joinpath("build", "lib", "libfoo")
+    @wrapmodule () -> joinpath("build", "lib", "libfoo")
 
     function __init__()
         @initcxx


### PR DESCRIPTION
I was using this template and noticed a couple things were not working
- The .devcontainer extensions format
-  The cmake < 3.5 depreciation warnings
- @wrapmodule being passed the path instead of a function

This PR fixes these.